### PR TITLE
Parse diff files produced by git diff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,7 @@ cabal-dev
 *.hi
 *.chi
 *.chs.h
-.virtualenv
+.virthualenv
 .hsenv
 .cabal-sandbox/
 cabal.sandbox.config
-cabal.config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: haskell

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-diff-parse
-==========
+# diff-parse
+
+TODO: Write description here
+
+## Installation
+
+TODO: Write installation instructions here
+
+## Usage
+
+TODO: Write usage instructions here
+
+## How to run tests
+
+```
+cabal configure --enable-tests && cabal build && cabal test
+```
+
+## Contributing
+
+TODO: Write contribution instructions here

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/diff-parse.cabal
+++ b/diff-parse.cabal
@@ -1,0 +1,40 @@
+Name:                   diff-parse
+Version:                0.1.0.0
+Author:                 Gabe Mulley <gabe@edx.org>
+Maintainer:             Gabe Mulley <gabe@edx.org>
+Category:               Parsing
+License:                AGPL-3
+License-File:           LICENSE
+Synopsis:               A parser for diff file formats
+Description:            Parse output produced by git diff.
+Cabal-Version:          >= 1.18
+Build-Type:             Simple
+
+Library
+  Default-Language:     Haskell2010
+  HS-Source-Dirs:       src
+  GHC-Options:          -Wall
+  Exposed-Modules:      Text.Diff.Parse
+  Other-Modules:        Text.Diff.Parse.Internal
+                      , Text.Diff.Parse.Types
+  Build-Depends:        base >= 4 && < 5
+                      , text == 1.1.*
+                      , attoparsec == 0.12.*
+  Other-Extensions:     OverloadedStrings
+
+Test-Suite spec
+  Type:                 exitcode-stdio-1.0
+  Default-Language:     Haskell2010
+  Hs-Source-Dirs:       src
+                      , test
+  Ghc-Options:          -Wall
+  Main-Is:              Spec.hs
+  Build-Depends:        base >= 4 && < 5
+                      , text == 1.1.*
+                      , attoparsec == 0.12.*
+                      , hspec == 1.10.*
+  Other-Extensions:     OverloadedStrings
+
+Source-Repository head
+  Type:                 git
+  Location:             https://github.com/mulby/diff-parse.git

--- a/src/Text/Diff/Parse.hs
+++ b/src/Text/Diff/Parse.hs
@@ -1,0 +1,3 @@
+module Text.Diff.Parse (parseDiff) where
+
+import Text.Diff.Parse.Internal

--- a/src/Text/Diff/Parse/Internal.hs
+++ b/src/Text/Diff/Parse/Internal.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Text.Diff.Parse.Internal 
+    ( parseDiff
+    , diff
+    , annotation
+    , annotatedLine
+    , hunk
+    , fileDelta
+    , fileDeltaHeader
+    ) where
+
+import Text.Diff.Parse.Types
+
+import Control.Applicative ((<|>), (*>), (<*), (<$>), (<*>), many)
+import Data.Text (Text)
+
+import Data.Attoparsec.Text
+    ( Parser
+    , parseOnly
+    , many1
+    , takeTill
+    , char
+    , string
+    , option
+    , isEndOfLine
+    , endOfLine
+    , decimal
+    , endOfInput
+    , letter
+    )
+
+
+parseDiff :: Text -> Either String FileDeltas
+parseDiff input = parseOnly diff input
+
+diff :: Parser FileDeltas
+diff = many1 fileDelta <* endOfInput
+
+fileDelta :: Parser FileDelta
+fileDelta = do
+    (status, source, dest) <- fileDeltaHeader
+    hunks  <- many hunk
+    _      <- option "" (string "\\ No newline at end of file" <* endOfLine)
+    return $ FileDelta status source dest hunks
+
+fileDeltaHeader :: Parser (FileStatus, Text, Text)
+fileDeltaHeader = do
+    _      <- string "diff --git " >> takeLine
+    status <- fileStatus
+    _      <- option "" (string "index" >> takeLine)
+    source <- string "--- " *> path
+    dest   <- string "+++ " *> path
+    return $ (status, source, dest)
+
+takeLine :: Parser Text
+takeLine = takeTill isEndOfLine <* endOfLine
+
+fileStatus :: Parser FileStatus
+fileStatus = option Modified $ ((string "new" *> return Created) <|> (string "deleted" *> return Deleted)) <* string " file mode" <* takeLine
+
+path :: Parser Text
+path = option "" (letter >> string "/") *> takeLine
+
+hunk :: Parser Hunk
+hunk = Hunk <$> ("@@ -" *> range)
+            <*> (" +" *> range <* " @@" <* endOfLine)
+            <*> (many annotatedLine)
+
+range :: Parser Range
+range = Range <$> decimal <*> (option 1 ("," *> decimal))
+
+annotatedLine :: Parser Line
+annotatedLine = Line <$> annotation <*> takeLine
+
+annotation :: Parser Annotation
+annotation = (char '+' >> return Added)
+         <|> (char '-' >> return Removed)
+         <|> (char ' ' >> return Context)

--- a/src/Text/Diff/Parse/Types.hs
+++ b/src/Text/Diff/Parse/Types.hs
@@ -1,0 +1,32 @@
+module Text.Diff.Parse.Types where
+
+import Data.Text (Text)
+
+data Annotation = Added | Removed | Context deriving (Show, Eq)
+
+data Line = Line {
+    lineAnnotation :: Annotation
+  , lineContent    :: Text
+} deriving (Show, Eq)
+
+data Range = Range {
+    rangeStartingLineNumber :: Int
+  , rangeNumberOfLines      :: Int
+} deriving (Show, Eq)
+
+data Hunk = Hunk {
+    hunkSourceRange :: Range
+  , hunkDestRange   :: Range
+  , hunkLines       :: [Line]
+} deriving (Show, Eq)
+
+data FileStatus = Created | Deleted | Modified deriving (Show, Eq)
+
+data FileDelta = FileDelta {
+    fileDeltaStatus     :: FileStatus
+  , fileDeltaSourceFile :: Text
+  , fileDeltaDestFile   :: Text
+  , fileDeltaHunks      :: [Hunk]
+} deriving (Show, Eq)
+
+type FileDeltas = [FileDelta]

--- a/test/DiffSpec.hs
+++ b/test/DiffSpec.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module DiffSpec (main, spec) where
+
+import Data.Text (pack)
+
+import Data.Attoparsec.Text (parseOnly)
+import Test.Hspec
+
+import Text.Diff.Parse.Types
+import Text.Diff.Parse.Internal
+    ( annotation
+    , annotatedLine
+    , hunk
+    , fileDelta
+    , fileDeltaHeader
+    , diff
+    , parseDiff
+    )
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+
+    describe "annotation" $ do
+        it "should parse added lines" $ do
+            (parseOnly annotation $ pack "+") `shouldBe` Right Added
+
+        it "should parse removed lines" $ do
+            (parseOnly annotation $ pack "-") `shouldBe` Right Removed
+
+        it "should parse context" $ do
+            (parseOnly annotation $ pack " ") `shouldBe` Right Context
+
+    describe "annotatedLine" $ do
+        it "should parse a complete line" $ do
+            (parseOnly annotatedLine $ pack "+Foo bar baz\n") `shouldBe` Right (Line Added "Foo bar baz")
+
+    describe "hunk" $ do
+        it "should parse a hunk" $ do
+            let testText = unlines [ "@@ -1,2 +4,3 @@",
+                                     "-x",
+                                     "+y",
+                                     "+w",
+                                     " z\n"]
+            let expectedHunk = Hunk (Range 1 2) (Range 4 3) [ (Line Removed "x")
+                                                            , (Line Added "y")
+                                                            , (Line Added "w")
+                                                            , (Line Context "z")
+                                                            ]
+            (parseOnly hunk $ pack testText) `shouldBe` Right expectedHunk
+    
+    describe "fileDeltaHeader" $ do
+        it "should parse file delta header" $ do
+            let testText = unlines [ "diff --git a/foo.txt b/foo.txt",
+                                     "index 8a19e19..99f4dc4 100644",
+                                     "--- a/foo.txt",
+                                     "+++ b/foo.txt\n" ]
+            (parseOnly fileDeltaHeader $ pack testText) `shouldBe` Right (Modified, "foo.txt", "foo.txt")
+
+        it "should parse added file delta header" $ do
+            let testText = unlines [ "diff --git a/foo.txt b/foo.txt",
+                                    "new file mode 100644",
+                                    "index 0000000..c698226",
+                                     "--- /dev/null",
+                                     "+++ b/foo.txt\n" ]
+            (parseOnly fileDeltaHeader $ pack testText) `shouldBe` Right (Created, "/dev/null", "foo.txt")
+
+        it "should parse removed file delta header" $ do
+            let testText = unlines [ "diff --git a/foo.txt b/foo.txt",
+                                    "deleted file mode 100644",
+                                    "index 80ef287..0000000",
+                                     "--- a/foo.txt",
+                                     "+++ /dev/null\n" ]
+            (parseOnly fileDeltaHeader $ pack testText) `shouldBe` Right (Deleted, "foo.txt", "/dev/null")
+
+    describe "fileDelta" $ do
+        it "should parse a file delta with multiple hunks" $ do
+            let testText = unlines [ "diff --git a/foo.txt b/bar.txt",
+                                     "index 8a19e19..99f4dc4 100644",
+                                     "--- a/foo.txt",
+                                     "+++ b/bar.txt",
+                                     "@@ -1,2 +4,3 @@",
+                                     "-x",
+                                     "+y",
+                                     "+w",
+                                     " z",
+                                     "@@ -1,2 +4,3 @@",
+                                     "-x",
+                                     "+y",
+                                     "+w",
+                                     " z"]
+            let expectedHunk = Hunk (Range 1 2) (Range 4 3) [ (Line Removed "x")
+                                                            , (Line Added "y")
+                                                            , (Line Added "w")
+                                                            , (Line Context "z")
+                                                            ]
+            (parseOnly fileDelta $ pack testText) `shouldBe` Right (FileDelta Modified "foo.txt" "bar.txt" [expectedHunk, expectedHunk])
+
+        it "should parse a diff with multiple file deltas" $ do
+            let testText = unlines [ "diff --git a/foo.txt b/bar.txt",
+                                     "index 8a19e19..99f4dc4 100644",
+                                     "--- a/foo.txt",
+                                     "+++ b/bar.txt",
+                                     "@@ -1,2 +4,3 @@",
+                                     "-x",
+                                     "+y",
+                                     "+w",
+                                     " z",
+                                     "@@ -1,2 +4,3 @@",
+                                     "-x",
+                                     "+y",
+                                     "+w",
+                                     " z",
+                                     "diff --git a/foo.txt b/bar.txt",
+                                     "index 8a19e19..99f4dc4 100644",
+                                     "--- a/foo.txt",
+                                     "+++ b/bar.txt",
+                                     "@@ -1,2 +4,3 @@",
+                                     "-x",
+                                     "+y",
+                                     "+w",
+                                     " z",
+                                     "@@ -1,2 +4,3 @@",
+                                     "-x",
+                                     "+y",
+                                     "+w",
+                                     " z"]
+            let expectedHunk = Hunk (Range 1 2) (Range 4 3) [ (Line Removed "x")
+                                                            , (Line Added "y")
+                                                            , (Line Added "w")
+                                                            , (Line Context "z")
+                                                            ]
+            let expectedFileDelta = FileDelta Modified "foo.txt" "bar.txt" [expectedHunk, expectedHunk]
+            (parseOnly diff $ pack testText) `shouldBe` Right ([expectedFileDelta, expectedFileDelta])
+
+    describe "parseDiff" $ do
+
+        it "should parse a complex diff" $ do
+            let testText = unlines ["diff --git a/bar.txt b/bar.txt",
+                                    "deleted file mode 100644",
+                                    "index 363a6c1..0000000",
+                                    "--- a/bar.txt",
+                                    "+++ /dev/null",
+                                    "@@ -1 +0,0 @@",
+                                    "-bar 1",
+                                    "diff --git a/baz.txt b/baz.txt",
+                                    "deleted file mode 100644",
+                                    "index 80ef287..0000000",
+                                    "--- a/baz.txt",
+                                    "+++ /dev/null",
+                                    "@@ -1,2 +0,0 @@",
+                                    "-baz 1",
+                                    "-baz 2",
+                                    "diff --git a/foo.txt b/foo.txt",
+                                    "index 9c2a709..9254400 100644",
+                                    "--- a/foo.txt",
+                                    "+++ b/foo.txt",
+                                    "@@ -1,4 +1,5 @@",
+                                    "+line 0",
+                                    " line 1",
+                                    "-line 2",
+                                    " line 3",
+                                    "+line 3.5",
+                                    " line 4",
+                                    "\\ No newline at end of file",
+                                    "diff --git a/renamed.txt b/renamed.txt",
+                                    "new file mode 100644",
+                                    "index 0000000..c698226",
+                                    "--- /dev/null",
+                                    "+++ b/renamed.txt",
+                                    "@@ -0,0 +1,3 @@",
+                                    "+baz 1",
+                                    "+baz 10",
+                                    "+baz 12",
+                                    "\\ No newline at end of file"]
+
+            let barDiff = FileDelta Deleted "bar.txt" "/dev/null" [Hunk (Range 1 1) (Range 0 0) [Line Removed "bar 1"]]
+                bazDiff = FileDelta Deleted "baz.txt" "/dev/null" [Hunk (Range 1 2) (Range 0 0) [ Line Removed "baz 1"
+                                                                                                , Line Removed "baz 2"
+                                                                                                ]]
+                fooDiff = FileDelta Modified "foo.txt" "foo.txt" [Hunk (Range 1 4) (Range 1 5) [ Line Added "line 0"
+                                                                                               , Line Context "line 1"
+                                                                                               , Line Removed "line 2"
+                                                                                               , Line Context "line 3"
+                                                                                               , Line Added "line 3.5"
+                                                                                               , Line Context "line 4"
+                                                                                               ]]
+                renamedDiff = FileDelta Created "/dev/null" "renamed.txt" [Hunk (Range 0 0) (Range 1 3) [ Line Added "baz 1"
+                                                                                                        , Line Added "baz 10"
+                                                                                                        , Line Added "baz 12"
+                                                                                                        ]]
+            (parseDiff $ pack testText) `shouldBe` Right [barDiff, bazDiff, fooDiff, renamedDiff]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,0 +1,1 @@
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}


### PR DESCRIPTION
@cpennington

FYI Still a major bug in here related to the consumption of newlines... note the test for fileDelta that requires 4 "\n" chars at the end of the block for it parse.
