### PR TITLE
Parse binary diffs

### DIFF
--- a/src/Text/Diff/Parse/Internal.hs
+++ b/src/Text/Diff/Parse/Internal.hs
@@ -42,7 +42,7 @@ diff = many1 fileDelta <* endOfInput
 fileDelta :: Parser FileDelta
 fileDelta = do
     (status, source, dest) <- fileDeltaHeader
-    hunks  <- many hunk
+    hunks  <- Hunks <$> many hunk
     return $ FileDelta status source dest hunks
 
 fileDeltaHeader :: Parser (FileStatus, Text, Text)

--- a/src/Text/Diff/Parse/Internal.hs
+++ b/src/Text/Diff/Parse/Internal.hs
@@ -13,6 +13,7 @@ module Text.Diff.Parse.Internal
 import Text.Diff.Parse.Types
 
 import Control.Applicative ((<|>), (*>), (<*), (<$>), (<*>), many)
+import Control.Monad (void)
 import Data.Char (isSpace)
 import Data.Text (Text)
 
@@ -30,6 +31,7 @@ import Data.Attoparsec.Text
     , endOfInput
     , letter
     , space
+    , try
     )
 
 
@@ -42,8 +44,8 @@ diff = many1 fileDelta <* endOfInput
 fileDelta :: Parser FileDelta
 fileDelta = do
     (status, source, dest) <- fileDeltaHeader
-    hunks  <- Hunks <$> many hunk
-    return $ FileDelta status source dest hunks
+    content <- try binary <|> hunks
+    return $ FileDelta status source dest content
 
 fileDeltaHeader :: Parser (FileStatus, Text, Text)
 fileDeltaHeader = do
@@ -65,10 +67,22 @@ fileStatus = option Modified $ ((string "new" *> return Created) <|> (string "de
 path :: Parser Text
 path = option "" (letter >> string "/") *> takeTill (\c -> (isSpace c) || (isEndOfLine c))
 
+hunks :: Parser Content
+hunks = Hunks <$> many hunk
+
 hunk :: Parser Hunk
 hunk = Hunk <$> ("@@ -" *> range)
             <*> (" +" *> range <* " @@" <* takeLine)
             <*> (many annotatedLine)
+
+binary :: Parser Content
+binary = do
+    void $ string "Binary files "
+        <* path <* string " and "
+        <* path <* string " differ"
+        <* endOfLine
+
+    return $ Binary
 
 range :: Parser Range
 range = Range <$> decimal <*> (option 1 ("," *> decimal))

--- a/src/Text/Diff/Parse/Types.hs
+++ b/src/Text/Diff/Parse/Types.hs
@@ -20,13 +20,15 @@ data Hunk = Hunk {
   , hunkLines       :: [Line]
 } deriving (Show, Eq)
 
+data Content = Binary | Hunks [Hunk] deriving (Show, Eq)
+
 data FileStatus = Created | Deleted | Modified deriving (Show, Eq)
 
 data FileDelta = FileDelta {
     fileDeltaStatus     :: FileStatus
   , fileDeltaSourceFile :: Text
   , fileDeltaDestFile   :: Text
-  , fileDeltaHunks      :: [Hunk]
+  , fileDeltaContent    :: Content
 } deriving (Show, Eq)
 
 type FileDeltas = [FileDelta]

--- a/test/DiffSpec.hs
+++ b/test/DiffSpec.hs
@@ -110,7 +110,7 @@ spec = do
                                                             , (Line Added "w")
                                                             , (Line Context "z")
                                                             ]
-            (parseOnly fileDelta $ pack testText) `shouldBe` Right (FileDelta Modified "foo.txt" "bar.txt" [expectedHunk, expectedHunk])
+            (parseOnly fileDelta $ pack testText) `shouldBe` Right (FileDelta Modified "foo.txt" "bar.txt" $ Hunks [expectedHunk, expectedHunk])
 
         it "should parse a diff with multiple file deltas" $ do
             let testText = unlines [ "diff --git a/foo.txt b/bar.txt",
@@ -146,7 +146,7 @@ spec = do
                                                             , (Line Added "w")
                                                             , (Line Context "z")
                                                             ]
-            let expectedFileDelta = FileDelta Modified "foo.txt" "bar.txt" [expectedHunk, expectedHunk]
+            let expectedFileDelta = FileDelta Modified "foo.txt" "bar.txt" $ Hunks [expectedHunk, expectedHunk]
             (parseOnly diff $ pack testText) `shouldBe` Right ([expectedFileDelta, expectedFileDelta])
 
     describe "parseDiff" $ do
@@ -193,20 +193,20 @@ spec = do
                                     "+baz 10",
                                     "+baz 12"]
 
-            let barDiff = FileDelta Deleted "bar.txt" "bar.txt" [Hunk (Range 1 1) (Range 0 0) [Line Removed "bar 1"]]
-                bazDiff = FileDelta Deleted "baz.txt" "baz.txt" [Hunk (Range 1 2) (Range 0 0) [ Line Removed "baz 1"
+            let barDiff = FileDelta Deleted "bar.txt" "bar.txt" (Hunks [Hunk (Range 1 1) (Range 0 0) [Line Removed "bar 1"]])
+                bazDiff = FileDelta Deleted "baz.txt" "baz.txt" (Hunks [Hunk (Range 1 2) (Range 0 0) [ Line Removed "baz 1"
                                                                                                 , Line Removed "baz 2"
-                                                                                                ]]
-                fooDiff = FileDelta Modified "foo.txt" "foo.txt" [Hunk (Range 1 4) (Range 1 5) [ Line Added "line 0"
+                                                                                                ]])
+                fooDiff = FileDelta Modified "foo.txt" "foo.txt" (Hunks [Hunk (Range 1 4) (Range 1 5) [ Line Added "line 0"
                                                                                                , Line Context "line 1"
                                                                                                , Line Removed "line 2"
                                                                                                , Line Context "line 3"
                                                                                                , Line Added "line 3.5"
                                                                                                , Line Context "line 4"
-                                                                                               ]]
-                renamedDiff = FileDelta Created "renamed.txt" "renamed.txt" [Hunk (Range 0 0) (Range 1 3) [ Line Added "baz 1"
+                                                                                               ]])
+                renamedDiff = FileDelta Created "renamed.txt" "renamed.txt" (Hunks [Hunk (Range 0 0) (Range 1 3) [ Line Added "baz 1"
                                                                                                         , Line Added "baz 10"
                                                                                                         , Line Added "baz 12"
-                                                                                                        ]]
-                emptyDiff = FileDelta Created "empty.txt" "empty.txt" []
+                                                                                                        ]])
+                emptyDiff = FileDelta Created "empty.txt" "empty.txt" $ Hunks []
             (parseDiff $ pack testText) `shouldBe` Right [barDiff, bazDiff, fooDiff, emptyDiff, renamedDiff]

--- a/test/DiffSpec.hs
+++ b/test/DiffSpec.hs
@@ -210,3 +210,13 @@ spec = do
                                                                                                         ]])
                 emptyDiff = FileDelta Created "empty.txt" "empty.txt" $ Hunks []
             (parseDiff $ pack testText) `shouldBe` Right [barDiff, bazDiff, fooDiff, emptyDiff, renamedDiff]
+
+        it "should parse binary diffs" $ do
+            let testText = unlines ["diff --git a/binary.png b/binary.png",
+                                    "new file mode 100644",
+                                    "index 0000000..363a6c1",
+                                    "Binary files /dev/null and b/binary.png differ"]
+
+                binaryDiff = FileDelta Created "binary.png" "binary.png" Binary
+
+            (parseDiff $ pack testText) `shouldBe` Right [binaryDiff]


### PR DESCRIPTION
This is a breaking change, due to adding the new `Content` type and changing `fileDeltaHunks`. I guess it could be done in a compatible way by returning an empty list of Hunks for Binary diffs, but that felt less semantically valuable.