### PR TITLE
Parse diffs which contain file mode changes

### DIFF
--- a/src/Text/Diff/Parse/Internal.hs
+++ b/src/Text/Diff/Parse/Internal.hs
@@ -62,7 +62,10 @@ takeLine :: Parser Text
 takeLine = takeTill isEndOfLine <* endOfLine
 
 fileStatus :: Parser FileStatus
-fileStatus = option Modified $ ((string "new" *> return Created) <|> (string "deleted" *> return Deleted)) <* string " file mode" <* takeLine
+fileStatus = do
+    _ <- option "" (string "old mode " >> takeLine)
+    _ <- option "" (string "new mode " >> takeLine)
+    option Modified $ ((string "new" *> return Created) <|> (string "deleted" *> return Deleted)) <* string " file mode" <* takeLine
 
 path :: Parser Text
 path = option "" (letter >> string "/") *> takeTill (\c -> (isSpace c) || (isEndOfLine c))

--- a/test/DiffSpec.hs
+++ b/test/DiffSpec.hs
@@ -220,3 +220,18 @@ spec = do
                 binaryDiff = FileDelta Created "binary.png" "binary.png" Binary
 
             (parseDiff $ pack testText) `shouldBe` Right [binaryDiff]
+
+        it "should parse a file delta with a mode change" $ do
+            let testText = unlines [ "diff --git a/foo.txt b/bar.txt",
+                                     "old mode 100644",
+                                     "new mode 100755",
+                                     "index fcd15ac..f4ca464",
+                                     "--- a/foo.txt",
+                                     "+++ b/bar.txt",
+                                     "@@ -1 +1 @@",
+                                     "-abc",
+                                     "+abcd"]
+
+                hunklessDiff = FileDelta Modified "foo.txt" "bar.txt" $ Hunks [Hunk (Range 1 1) (Range 1 1) [Line Removed "abc", Line Added "abcd"]]
+
+            (parseDiff $ pack testText) `shouldBe` Right [hunklessDiff]


### PR DESCRIPTION
The parser doesn't return any information about file modes, but diffs which contained a mode change would crash the parser.

This commit extends the parser to ignore these mode changes.