### PR TITLE
Parse renamed files

### DIFF
--- a/src/Text/Diff/Parse/Internal.hs
+++ b/src/Text/Diff/Parse/Internal.hs
@@ -23,6 +23,7 @@ import Data.Attoparsec.Text
     , many1
     , takeTill
     , char
+    , choice
     , string
     , option
     , isEndOfLine
@@ -65,7 +66,14 @@ fileStatus :: Parser FileStatus
 fileStatus = do
     _ <- option "" (string "old mode " >> takeLine)
     _ <- option "" (string "new mode " >> takeLine)
-    option Modified $ ((string "new" *> return Created) <|> (string "deleted" *> return Deleted)) <* string " file mode" <* takeLine
+    _ <- option "" (string "similarity index " >> takeLine)
+    _ <- option "" (string "rename from " >> takeLine)
+    choice
+        [ (string "new file mode" >> takeLine *> return Created)
+        , (string "deleted file mode" >> takeLine *> return Deleted)
+        , (string "rename to " >> takeLine *> return Renamed)
+        , return Modified
+        ]
 
 path :: Parser Text
 path = option "" (letter >> string "/") *> takeTill (\c -> (isSpace c) || (isEndOfLine c))

--- a/src/Text/Diff/Parse/Types.hs
+++ b/src/Text/Diff/Parse/Types.hs
@@ -22,7 +22,7 @@ data Hunk = Hunk {
 
 data Content = Binary | Hunks [Hunk] deriving (Show, Eq)
 
-data FileStatus = Created | Deleted | Modified deriving (Show, Eq)
+data FileStatus = Created | Deleted | Modified | Renamed deriving (Show, Eq)
 
 data FileDelta = FileDelta {
     fileDeltaStatus     :: FileStatus

--- a/test/DiffSpec.hs
+++ b/test/DiffSpec.hs
@@ -89,6 +89,13 @@ spec = do
                                      "+++ /dev/null\n" ]
             (parseOnly fileDeltaHeader $ pack testText) `shouldBe` Right (Deleted, "foo.txt", "foo.txt")
 
+        it "should parse renamed file delta header" $ do
+            let testText = unlines [ "diff --git a/foo.txt b/bar.txt",
+                                     "similarity index 100%",
+                                     "rename from foo.txt",
+                                     "rename to bar.txt" ]
+            (parseOnly fileDeltaHeader $ pack testText) `shouldBe` Right (Renamed, "foo.txt", "bar.txt")
+
     describe "fileDelta" $ do
         it "should parse a file delta with multiple hunks" $ do
             let testText = unlines [ "diff --git a/foo.txt b/bar.txt",
@@ -191,7 +198,12 @@ spec = do
                                     "+baz 1",
                                     "\\ No newline at end of file",
                                     "+baz 10",
-                                    "+baz 12"]
+                                    "+baz 12",
+                                    "diff --git a/from.txt b/to.txt",
+                                    "similarity index 100%",
+                                    "rename from from.txt",
+                                    "rename to to.hs"
+                                    ]
 
             let barDiff = FileDelta Deleted "bar.txt" "bar.txt" (Hunks [Hunk (Range 1 1) (Range 0 0) [Line Removed "bar 1"]])
                 bazDiff = FileDelta Deleted "baz.txt" "baz.txt" (Hunks [Hunk (Range 1 2) (Range 0 0) [ Line Removed "baz 1"
@@ -209,7 +221,8 @@ spec = do
                                                                                                         , Line Added "baz 12"
                                                                                                         ]])
                 emptyDiff = FileDelta Created "empty.txt" "empty.txt" $ Hunks []
-            (parseDiff $ pack testText) `shouldBe` Right [barDiff, bazDiff, fooDiff, emptyDiff, renamedDiff]
+                renamedDiff2 = FileDelta Renamed "from.txt" "to.txt" $ Hunks []
+            (parseDiff $ pack testText) `shouldBe` Right [barDiff, bazDiff, fooDiff, emptyDiff, renamedDiff, renamedDiff2]
 
         it "should parse binary diffs" $ do
             let testText = unlines ["diff --git a/binary.png b/binary.png",


### PR DESCRIPTION
This patch adds `Renamed` constructor to `FileStatus` type and modifies `fileStatus` function so that it can parse patterns such as the following diff:

```diff
diff --git a/foo.txt b/bar.txt
similarity index 100%
rename from foo.txt
rename to bar.txt
```