### PR TITLE
Use hspec 2.4.* instead of old 1.10.*

### DIFF
--- a/diff-parse.cabal
+++ b/diff-parse.cabal
@@ -34,7 +34,7 @@ Test-Suite spec
                       , diff-parse
                       , attoparsec
                       , text
-                      , hspec == 1.10.*
+                      , hspec == 2.4.*
   Other-Extensions:     OverloadedStrings
 
 Source-Repository head


### PR DESCRIPTION
hspec 1.10.* was released about 3 years ago so that it's hard to use together with other libraries.  The current Travis CI build is also failed during installing hspec.  This fixes the broken build.